### PR TITLE
1755 Bugfix gson date format

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -189,11 +189,11 @@ class Client : ClientInterface {
 
     /** Resume any previously logged-in user session */
     override fun resumeLastLoggedInUser(callback: (User?) -> Unit) {
-        sessionStorage.get(configuration.clientId) {
-            if (it == null) {
+        sessionStorage.get(configuration.clientId) { storedUserSession ->
+            if (storedUserSession == null) {
                 callback(null)
             } else {
-                callback(User(this, it.userTokens))
+                callback(User(this, storedUserSession.userTokens))
             }
         }
     }


### PR DESCRIPTION
Since I have not been able to reproduce the bug, this is a potential fix that need to be tested out in production by brand. Since crash happend due to 
"Failed to parse date ["Oct 31, 2021 21:37:46"]: Invalid number: Oct"
dates are now stored as a number (10 for oct).