### PR TITLE
Is initialized fun for retrofitclient

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/client/RetrofitClient.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/RetrofitClient.kt
@@ -39,6 +39,13 @@ class RetrofitClient<S>(
         }
     }
 
+    /** Check if RetrofitClient has been initialized */
+    fun isInitialized(): Boolean {
+        user ?: return false
+        retrofitApi ?: return false
+        return true
+    }
+
     /**
      * Perform the given [request] with user access token as Bearer token in Authorization header.
      *


### PR DESCRIPTION
By request from developers. 
Check in order to know if they can use retrofitclient, or if resumeLastLoggedInUser is needed to be called before they can make authenticated requests.