### PR TITLE
Enable to forward filename to where legacy tokens are stored

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -53,7 +53,8 @@ class Client : ClientInterface {
                 context.applicationContext,
                 this,
                 sessionStorageConfig.legacyClientId,
-                sessionStorageConfig.legacyClientSecret
+                sessionStorageConfig.legacyClientSecret,
+                sessionStorageConfig.legacySharedPrefsFilename
             )
         } else {
             EncryptedSharedPrefsStorage(context.applicationContext)
@@ -311,4 +312,8 @@ sealed class RefreshTokenError {
 
 typealias LoginResultHandler = (Either<LoginError, User>) -> Unit
 
-data class SessionStorageConfig(val legacyClientId: String, val legacyClientSecret: String)
+data class SessionStorageConfig(
+    val legacyClientId: String,
+    val legacyClientSecret: String,
+    val legacySharedPrefsFilename: String? = null
+)

--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/compat/LegacySessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/compat/LegacySessionStorage.kt
@@ -26,10 +26,10 @@ internal data class LegacySession(
  *
  * @see <a href="https://github.com/schibsted/account-sdk-android/blob/master/core/src/main/java/com/schibsted/account/persistence/SessionStorageDelegate.kt" target="_top">Old Schibsted account Android SDK</a>
  */
-internal class LegacyTokenStorage(context: Context) {
+internal class LegacyTokenStorage(context: Context, legacySharedPrefsFilename: String?) {
     private var sessions: List<LegacySession> by SessionStorageDelegate(
         context,
-        PREFERENCE_FILENAME
+        legacySharedPrefsFilename ?: PREFERENCE_FILENAME
     )
 
     fun get(): Collection<LegacySession> {
@@ -46,7 +46,7 @@ internal class LegacyTokenStorage(context: Context) {
 }
 
 internal class LegacySessionStorage(private val legacyTokenStorage: LegacyTokenStorage) {
-    internal constructor(context: Context) : this(LegacyTokenStorage(context))
+    internal constructor(context: Context, legacySharedPrefsFilename: String?) : this(LegacyTokenStorage(context, legacySharedPrefsFilename))
 
     fun get(clientId: String): MigrationStoredUserSession? {
         val sessions = legacyTokenStorage.get()

--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/compat/MigratingSessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/compat/MigratingSessionStorage.kt
@@ -21,11 +21,12 @@ internal class MigratingSessionStorage(
         context: Context,
         client: Client,
         legacyClientId: String,
-        legacyClientSecret: String
+        legacyClientSecret: String,
+        legacySharedPrefsFilename: String?
     ) : this(
         client,
         EncryptedSharedPrefsStorage(context),
-        LegacySessionStorage(context),
+        LegacySessionStorage(context, legacySharedPrefsFilename),
         legacyClientId,
         legacyClientSecret
     )


### PR DESCRIPTION
- Solution in order to make it possible to migrate from old SPID sdk where tokens are not stored in same shared preference file as old sdk