### PR TITLE
Remove @SerializedName from tokens in LegacySession

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/compat/LegacySessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/compat/LegacySessionStorage.kt
@@ -18,7 +18,7 @@ internal data class LegacyUserTokens(
 internal data class LegacySession(
     val lastActive: Long,
     val userId: String,
-    @SerializedName("token") val tokens: LegacyUserTokens
+    val token: LegacyUserTokens
 )
 
 /**
@@ -61,13 +61,13 @@ internal class LegacySessionStorage(private val legacyTokenStorage: LegacyTokenS
     }
 
     private fun toStoredUserSession(legacySession: LegacySession): MigrationStoredUserSession? {
-        val accessToken = legacySession.tokens.accessToken
+        val accessToken = legacySession.token.accessToken
         val clientId = unverifiedClaims(accessToken)?.get("client_id") ?: return null
-        val refreshToken = legacySession.tokens.refreshToken ?: return null
+        val refreshToken = legacySession.token.refreshToken ?: return null
 
-        val idToken = legacySession.tokens.idToken
+        val idToken = legacySession.token.idToken
         val userTokens = MigrationUserTokens(
-            accessToken = legacySession.tokens.accessToken,
+            accessToken = legacySession.token.accessToken,
             refreshToken = refreshToken,
             idToken = idToken,
             idTokenClaims = createIdTokenClaims(idToken)

--- a/webflows/src/test/java/com/schibsted/account/webflows/persistence/compat/LegacySessionStorageTest.kt
+++ b/webflows/src/test/java/com/schibsted/account/webflows/persistence/compat/LegacySessionStorageTest.kt
@@ -9,9 +9,7 @@ import com.schibsted.account.testutil.createJws
 import com.schibsted.account.webflows.token.IdTokenClaims
 import com.schibsted.account.webflows.token.IdTokenValidatorTest
 import com.schibsted.account.webflows.token.MigrationUserTokens
-import com.schibsted.account.webflows.token.UserTokens
 import com.schibsted.account.webflows.user.MigrationStoredUserSession
-import com.schibsted.account.webflows.user.StoredUserSession
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -38,9 +36,9 @@ class LegacySessionStorageTest {
         return MigrationStoredUserSession(
             clientId,
             MigrationUserTokens(
-                legacySession.tokens.accessToken,
-                legacySession.tokens.refreshToken ?: "",
-                legacySession.tokens.idToken,
+                legacySession.token.accessToken,
+                legacySession.token.refreshToken ?: "",
+                legacySession.token.idToken,
                 idTokenClaims.copy(aud = emptyList())
             ),
             Date(legacySession.lastActive)
@@ -95,7 +93,7 @@ class LegacySessionStorageTest {
     fun testExistingLegacyDataWithoutRefreshTokenIsIgnored() {
         val existingSession = createLegacySession(clientId, Fixtures.idTokenClaims)
         val existingSessionWithoutRefreshToken =
-            existingSession.copy(tokens = existingSession.tokens.copy(refreshToken = null))
+            existingSession.copy(token = existingSession.token.copy(refreshToken = null))
         val legacyTokenStorage = mockk<LegacyTokenStorage> {
             every { get() } returns listOf(existingSessionWithoutRefreshToken)
         }
@@ -108,7 +106,7 @@ class LegacySessionStorageTest {
     fun testExistingLegacyDataWithoutIdTokenIsNotIgnored() {
         val existingSession = createLegacySession(clientId, Fixtures.idTokenClaims)
         val existingSessionWithoutIdToken =
-            existingSession.copy(tokens = existingSession.tokens.copy(idToken = null))
+            existingSession.copy(token = existingSession.token.copy(idToken = null))
         val legacyTokenStorage = mockk<LegacyTokenStorage> {
             every { get() } returns listOf(existingSessionWithoutIdToken)
         }


### PR DESCRIPTION
- In order to allow developers of SDK to use Proguard -keepattributes *Annotation* for migration flow