### PR TITLE
AMR for Eid will only contain eid without prefix

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/token/IdTokenValidator.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/token/IdTokenValidator.kt
@@ -109,8 +109,8 @@ internal class IdTokenClaimsVerifier(
         val haystack = values ?: return false // no values to search among
 
         // Regardless of country, AMR will only contain EID value
-        if (needle == MfaType.EID_NO || needle == MfaType.EID_SE) {
-            needle = MfaType.EID
+        if (needle == MfaType.EID_NO.value || needle == MfaType.EID_SE.value) {
+            needle = MfaType.EID.value
         }
         return haystack.contains(needle)
     }

--- a/webflows/src/main/java/com/schibsted/account/webflows/token/IdTokenValidator.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/token/IdTokenValidator.kt
@@ -13,6 +13,7 @@ import com.schibsted.account.webflows.jose.AsyncJwks
 import com.schibsted.account.webflows.util.Either
 import com.schibsted.account.webflows.util.Either.Left
 import com.schibsted.account.webflows.util.Either.Right
+import com.schibsted.account.webflows.client.MfaType
 
 internal sealed class IdTokenValidationError {
     abstract val message: String
@@ -104,9 +105,13 @@ internal class IdTokenClaimsVerifier(
     }
 
     private fun contains(values: List<String>?, value: String?): Boolean {
-        val needle = value ?: return true // no value to search for
+        var needle = value ?: return true // no value to search for
         val haystack = values ?: return false // no values to search among
 
+        // Regardless of country, AMR will only contain EID value
+        if (needle == MfaType.EID_NO || needle == MfaType.EID_SE) {
+            needle = MfaType.EID
+        }
         return haystack.contains(needle)
     }
 }

--- a/webflows/src/test/java/com/schibsted/account/webflows/token/IdTokenValidatorTest.kt
+++ b/webflows/src/test/java/com/schibsted/account/webflows/token/IdTokenValidatorTest.kt
@@ -88,6 +88,19 @@ class IdTokenValidatorTest {
     }
 
     @Test
+    fun testAcceptsEidAMRWithoutCountryPrefix() {
+        val expectedAmrValue = "eid-se"
+        val context = IdTokenValidationContext(issuer, clientId, nonce, expectedAmrValue)
+        val claims = defaultIdTokenClaims()
+            .claim("amr", listOf("eid", "otherValue"))
+            .build()
+        val idToken = createIdToken(claims)
+        IdTokenValidator.validate(idToken, TestJwks(jwks), context) { result ->
+            result.assertRight { assertEquals(idTokenClaims(claims), it) }
+        }
+    }
+
+    @Test
     fun testRejectMissingExpectedAMRInIdTokenWithoutAMR() {
         val context = IdTokenValidationContext(issuer, clientId, nonce, "testValue")
 


### PR DESCRIPTION
For PRE we are requesting ACR: `eid-se` or `eid-no` to be able to differentiate different eid methods for Norway and Sweden. But resulted AMR is simply `eid` to keep it consistent with Production. This PR aims to fix IDTokenValidator to expect `AMR=eid` if requested ACR value is `eid-se` or eid-no`