### PR TITLE
feature/66 Remove encrypted shared preferences if master key is corru…

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
@@ -8,6 +8,10 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonSyntaxException
 import com.schibsted.account.webflows.user.StoredUserSession
+import timber.log.Timber
+import java.io.File
+import java.security.GeneralSecurityException
+import java.security.KeyStore
 
 /**
  * User session storage.
@@ -25,11 +29,41 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
     private val gson = GsonBuilder().setDateFormat("MM dd, yyyy HH:mm:ss").create()
 
     private val prefs: SharedPreferences by lazy {
+        getSharedPreferences(context)
+    }
+
+    /**
+     * Gets the encrypted shared preferences.
+     *
+     * This method will try and build the encrypted shared preferences, and in case of an error,
+     * it will delete the existing file from the filesystem and attempt to recreate it.
+     *
+     * A layer of thread safeness is needed to be sure the shared preferences is only accessed
+     * by one invoker at a time, to reduce potential corruption.
+     */
+    @Synchronized
+    private fun getSharedPreferences(context: Context): SharedPreferences {
+        return try {
+            buildSharedPreferences(context)
+        } catch (e: GeneralSecurityException) {
+            e.printStackTrace()
+
+            Timber.e("Error occurred while trying to build shared preferences, trying to recover", e)
+
+            deleteSharedPreferences(context)
+
+            buildSharedPreferences(context)
+        }
+    }
+
+    private fun buildSharedPreferences(context: Context): SharedPreferences {
+        Timber.d("Building the encrypted shared preferences")
+
         val masterKey = MasterKey.Builder(context.applicationContext)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build()
 
-        EncryptedSharedPreferences.create(
+        return EncryptedSharedPreferences.create(
             context.applicationContext,
             PREFERENCE_FILENAME,
             masterKey,
@@ -38,6 +72,43 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
         )
     }
 
+    /**
+     * Deletes the encrypted shared preferences.
+     *
+     * This method will try and find the actual shared preferences xml file and delete it. It
+     * will also try to delete the master key entry in the keystore.
+     */
+    private fun deleteSharedPreferences(context: Context) {
+        Timber.d("Trying to delete encrypted shared preferences")
+
+        try {
+            val sharedPreferencesFile = File(context.filesDir?.parent + "/shared_prefs/" + PREFERENCE_FILENAME + ".xml")
+
+            Timber.d("Shared preferences location: ${sharedPreferencesFile.absolutePath}")
+
+            if (sharedPreferencesFile.exists()) {
+                val deleted = sharedPreferencesFile.delete()
+
+                Timber.d("deleteSharedPreferences() Shared prefs file deleted: $deleted; path: ${sharedPreferencesFile.absolutePath}")
+            } else {
+                Timber.d("deleteSharedPreferences() Shared prefs file non-existent; path: ${sharedPreferencesFile.absolutePath}")
+            }
+
+            Timber.d("Deleting master key entry in keystore")
+
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            keyStore.deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+
+            Timber.d("Finished deleting encrypted shared preferences")
+        } catch (e: Exception) {
+            e.printStackTrace()
+
+            Timber.e("Error occurred while trying to delete encrypted shared preferences", e)
+        }
+    }
+
+    @Synchronized
     override fun save(session: StoredUserSession) {
         val editor = prefs.edit()
         val json = gson.toJson(session)
@@ -45,6 +116,7 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
         editor.apply()
     }
 
+    @Synchronized
     override fun get(clientId: String, callback: (StoredUserSession?) -> Unit) {
         val json = prefs.getString(clientId, null) ?: return callback(null)
         callback(gson.getStoredUserSession(json) ?: Gson().getStoredUserSession(json))
@@ -58,6 +130,7 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
         }
     }
 
+    @Synchronized
     override fun remove(clientId: String) {
         val editor = prefs.edit()
         editor.remove(clientId)


### PR DESCRIPTION
**Why this change**
The master key can sometimes get corrupted and there's no way to recover from it. The solution was to delete the master key and the data associated with it, and then recreating the key. The user might have to re-login. The tokens in memory might just update the current values. I had no way to reproduce the issue, but when I tried to damage the actual shared preferences xml file (altering contents, removing the file etc) I had various experiences where the tokens where just updated, and sometimes I had to re-login.

**What was changed**
Session storage was changed to removing the encrypted shared preferences if there is an error acquiring it. Synchronized annotation was also put on all places that touch the preferences. 