### PR TITLE
feature/72 Fix so SDK do not parse 500 response code and also check f…

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/user/User.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/user/User.kt
@@ -171,9 +171,11 @@ class User {
         fun shouldLogout(result: TokenRefreshResult?): Boolean {
             return result is Left &&
                     result.value is RefreshTokenError.RefreshRequestFailed &&
-                    result.value.error is HttpError.ErrorResponse &&
-                    result.value.error.body != null &&
-                    OAuthError.fromJson(result.value.error.body).error == "invalid_grant"
+                    result.value.error is HttpError.ErrorResponse && (
+                        result.value.error.code == 500 ||
+                        result.value.error.body == null ||
+                        OAuthError.fromJson(result.value.error.body).error == "invalid_grant"
+                    )
         }
 
         if (shouldLogout(result)) {

--- a/webflows/src/main/java/com/schibsted/account/webflows/user/User.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/user/User.kt
@@ -173,7 +173,7 @@ class User {
                     result.value is RefreshTokenError.RefreshRequestFailed &&
                     result.value.error is HttpError.ErrorResponse && (
                         result.value.error.code == 500 ||
-                        result.value.error.body == null ||
+                        result.value.error.body != null &&
                         OAuthError.fromJson(result.value.error.body).error == "invalid_grant"
                     )
         }


### PR DESCRIPTION
**Why this change**
Users were getting crashes when the SDK tried to parse HTML from a 500 error code.

**What was changed**
The parsing bit was changed to check for a 500 error code, and also as a bonus if the body is null. I talked with backend and they said the 500 error code will return HTML, while we expect JSON. Backend will transform 502 and 504 to a 500. I did not bother to do actual HTML checks because it felt too advanced, as 500 is the only response that will return HTML and not JSON.