### PR TITLE
feature/143 Change shared preference to be mutable and support being rebuilt

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
@@ -25,15 +25,33 @@ internal interface SessionStorage {
     fun remove(clientId: String)
 }
 
-internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
+internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorage {
     private val gson = GsonBuilder().setDateFormat("MM dd, yyyy HH:mm:ss").create()
 
-    private val prefs: SharedPreferences by lazy {
-        getSharedPreferences(context)
+    private var _sharedPreferences: SharedPreferences? = null
+
+    /**
+     * Returns the shared preferences.
+     *
+     * This method will check if the shared preferences has been initialized and takes the
+     * appropriate action.
+     *
+     * The shared preferences needs to be mutable as corrupted data can occur and then it needs
+     * to be purged and rebuilt.
+     */
+    @Synchronized
+    private fun getSharedPreferences(): SharedPreferences? {
+        if (_sharedPreferences != null) {
+            return _sharedPreferences
+        }
+
+        setupSharedPreferences(context)
+
+        return _sharedPreferences
     }
 
     /**
-     * Gets the encrypted shared preferences.
+     * Setup the encrypted shared preferences.
      *
      * This method will try and build the encrypted shared preferences, and in case of an error,
      * it will delete the existing file from the filesystem and attempt to recreate it.
@@ -41,14 +59,14 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
      * A layer of thread safeness is needed to be sure the shared preferences is only accessed
      * by one invoker at a time, to reduce potential corruption.
      */
-    @Synchronized
-    private fun getSharedPreferences(context: Context): SharedPreferences {
-        return try {
+    private fun setupSharedPreferences(context: Context) {
+        _sharedPreferences = try {
             buildSharedPreferences(context)
         } catch (e: GeneralSecurityException) {
-            e.printStackTrace()
-
-            Timber.e("Error occurred while trying to build shared preferences, trying to recover", e)
+            Timber.e(
+                "Error occurred while trying to build shared preferences, trying to recover",
+                e
+            )
 
             deleteSharedPreferences(context)
 
@@ -82,7 +100,8 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
         Timber.d("Trying to delete encrypted shared preferences")
 
         try {
-            val sharedPreferencesFile = File(context.filesDir?.parent + "/shared_prefs/" + PREFERENCE_FILENAME + ".xml")
+            val sharedPreferencesFile =
+                File(context.filesDir?.parent + "/shared_prefs/" + PREFERENCE_FILENAME + ".xml")
 
             Timber.d("Shared preferences location: ${sharedPreferencesFile.absolutePath}")
 
@@ -102,14 +121,35 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
 
             Timber.d("Finished deleting encrypted shared preferences")
         } catch (e: Exception) {
-            e.printStackTrace()
-
             Timber.e("Error occurred while trying to delete encrypted shared preferences", e)
         }
     }
 
     @Synchronized
     override fun save(session: StoredUserSession) {
+        val prefs = getSharedPreferences()
+            ?: throw IllegalStateException("Shared preferences has not been initialized")
+
+        try {
+            internalSave(prefs, session)
+        } catch (e: SecurityException) {
+            Timber.e(
+                "Error occurred while trying to save data to the encrypted shared preferences, trying to recover (saving the data again)",
+                e
+            )
+
+            deleteSharedPreferences(context)
+
+            setupSharedPreferences(context)
+
+            val rebuiltPrefs = getSharedPreferences()
+                ?: throw IllegalStateException("Shared preferences has not been initialized")
+
+            internalSave(rebuiltPrefs, session)
+        }
+    }
+
+    private fun internalSave(prefs: SharedPreferences, session: StoredUserSession) {
         val editor = prefs.edit()
         val json = gson.toJson(session)
         editor.putString(session.clientId, json)
@@ -118,8 +158,25 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
 
     @Synchronized
     override fun get(clientId: String, callback: (StoredUserSession?) -> Unit) {
-        val json = prefs.getString(clientId, null) ?: return callback(null)
-        callback(gson.getStoredUserSession(json) ?: Gson().getStoredUserSession(json))
+        val prefs = getSharedPreferences()
+            ?: throw IllegalStateException("Shared preferences has not been initialized")
+
+        try {
+            val json = prefs.getString(clientId, null) ?: return callback(null)
+
+            callback(gson.getStoredUserSession(json) ?: Gson().getStoredUserSession(json))
+        } catch (e: SecurityException) {
+            Timber.e(
+                "Error occurred while trying to get data from the encrypted shared preferences, trying to recover (returning null)",
+                e
+            )
+
+            deleteSharedPreferences(context)
+
+            setupSharedPreferences(context)
+
+            callback(null)
+        }
     }
 
     private fun Gson.getStoredUserSession(json: String): StoredUserSession? {
@@ -132,9 +189,23 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
 
     @Synchronized
     override fun remove(clientId: String) {
-        val editor = prefs.edit()
-        editor.remove(clientId)
-        editor.apply()
+        val prefs = getSharedPreferences()
+            ?: throw IllegalStateException("Shared preferences has not been initialized")
+
+        try {
+            val editor = prefs.edit()
+            editor.remove(clientId)
+            editor.apply()
+        } catch (e: SecurityException) {
+            Timber.e(
+                "Error occurred while trying to remove data from the encrypted shared preferences, trying to recover (purging all)",
+                e
+            )
+
+            deleteSharedPreferences(context)
+
+            setupSharedPreferences(context)
+        }
     }
 
     companion object {


### PR DESCRIPTION
**Why this change**
The shared preferences can crash if the data is corrupted. A change was necessary to make the shared preferences mutable and support being rebuilt, not only on instantiation but also dynamically when storing/retrieving values.

**What was changed**
The shared preferences is now mutable and support being purged and created anew. 