### PR TITLE
Rawo/add fail events stream to encrypted shared prefs

### DIFF
--- a/app/src/main/java/com/schibsted/account/example/ExampleApp.kt
+++ b/app/src/main/java/com/schibsted/account/example/ExampleApp.kt
@@ -39,7 +39,8 @@ class ExampleApp : Application() {
         client = Client(
             context = applicationContext,
             configuration = clientConfig,
-            httpClient = instance
+            httpClient = instance,
+            eventListener = LoggingEventListener()
         )
     }
 

--- a/app/src/main/java/com/schibsted/account/example/LoggingEventListener.kt
+++ b/app/src/main/java/com/schibsted/account/example/LoggingEventListener.kt
@@ -1,0 +1,46 @@
+package com.schibsted.account.example
+
+import android.util.Log
+import com.schibsted.account.webflows.client.listener.WebFlowsEventListener
+import java.security.GeneralSecurityException
+
+class LoggingEventListener : WebFlowsEventListener() {
+    override fun preferencesReadStart() {
+        Log.d("LoggingEventListener", "preferencesReadStart")
+    }
+
+    override fun preferencesReadEnd() {
+        Log.d("LoggingEventListener", "preferencesReadEnd")
+
+    }
+
+    override fun createEncryptedSharedPreferences() {
+        Log.d("LoggingEventListener", "createEncryptedSharedPreferences")
+
+    }
+
+    override fun createEncryptedSharedPreferencesFailure(e: GeneralSecurityException) {
+        Log.d("LoggingEventListener", "createEncryptedSharedPreferencesFailure")
+
+    }
+
+    override fun preferencesReadError(e: SecurityException) {
+        Log.d("LoggingEventListener", "preferencesReadError ${e.message}")
+
+    }
+
+    override fun deletePreferencesStart() {
+        Log.d("LoggingEventListener", "deletePreferencesStart")
+
+    }
+
+    override fun deletePreferencesEnd() {
+        Log.d("LoggingEventListener", "deletePreferencesEnd")
+
+    }
+
+    override fun deletePreferencesError() {
+        Log.d("LoggingEventListener", "deletePreferencesError")
+
+    }
+}

--- a/app/src/main/java/com/schibsted/account/example/LoggingEventListener.kt
+++ b/app/src/main/java/com/schibsted/account/example/LoggingEventListener.kt
@@ -1,46 +1,39 @@
 package com.schibsted.account.example
 
 import android.util.Log
-import com.schibsted.account.webflows.client.listener.WebFlowsEventListener
+import com.schibsted.account.webflows.client.listener.EncryptedSharedPreferencesEventListener
 import java.security.GeneralSecurityException
 
-class LoggingEventListener : WebFlowsEventListener() {
+class LoggingEventListener : EncryptedSharedPreferencesEventListener() {
     override fun preferencesReadStart() {
         Log.d("LoggingEventListener", "preferencesReadStart")
     }
 
     override fun preferencesReadEnd() {
         Log.d("LoggingEventListener", "preferencesReadEnd")
-
     }
 
     override fun createEncryptedSharedPreferences() {
         Log.d("LoggingEventListener", "createEncryptedSharedPreferences")
-
     }
 
     override fun createEncryptedSharedPreferencesFailure(e: GeneralSecurityException) {
         Log.d("LoggingEventListener", "createEncryptedSharedPreferencesFailure")
-
     }
 
     override fun preferencesReadError(e: SecurityException) {
         Log.d("LoggingEventListener", "preferencesReadError ${e.message}")
-
     }
 
     override fun deletePreferencesStart() {
         Log.d("LoggingEventListener", "deletePreferencesStart")
-
     }
 
     override fun deletePreferencesEnd() {
         Log.d("LoggingEventListener", "deletePreferencesEnd")
-
     }
 
-    override fun deletePreferencesError() {
+    override fun deletePreferencesError(e: Exception) {
         Log.d("LoggingEventListener", "deletePreferencesError")
-
     }
 }

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -8,7 +8,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import com.schibsted.account.webflows.activities.AuthorizationManagementActivity
 import com.schibsted.account.webflows.api.HttpError
 import com.schibsted.account.webflows.api.SchibstedAccountApi
-import com.schibsted.account.webflows.client.listener.WebFlowsEventListener
+import com.schibsted.account.webflows.client.listener.EncryptedSharedPreferencesEventListener
 import com.schibsted.account.webflows.persistence.EncryptedSharedPrefsStorage
 import com.schibsted.account.webflows.persistence.SessionStorage
 import com.schibsted.account.webflows.persistence.StateStorage
@@ -47,7 +47,7 @@ class Client : ClientInterface {
         httpClient: OkHttpClient,
         sessionStorageConfig: SessionStorageConfig? = null,
         logoutCallback: (() -> Unit)? = null,
-        eventListener: WebFlowsEventListener = WebFlowsEventListener.NONE
+        eventListener: EncryptedSharedPreferencesEventListener = EncryptedSharedPreferencesEventListener.NONE
     ) {
         this.configuration = configuration
         stateStorage = StateStorage(context.applicationContext)

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -8,6 +8,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import com.schibsted.account.webflows.activities.AuthorizationManagementActivity
 import com.schibsted.account.webflows.api.HttpError
 import com.schibsted.account.webflows.api.SchibstedAccountApi
+import com.schibsted.account.webflows.client.listener.WebFlowsEventListener
 import com.schibsted.account.webflows.persistence.EncryptedSharedPrefsStorage
 import com.schibsted.account.webflows.persistence.SessionStorage
 import com.schibsted.account.webflows.persistence.StateStorage
@@ -45,7 +46,8 @@ class Client : ClientInterface {
         configuration: ClientConfiguration,
         httpClient: OkHttpClient,
         sessionStorageConfig: SessionStorageConfig? = null,
-        logoutCallback: (() -> Unit)? = null
+        logoutCallback: (() -> Unit)? = null,
+        eventListener: WebFlowsEventListener = WebFlowsEventListener.NONE
     ) {
         this.configuration = configuration
         stateStorage = StateStorage(context.applicationContext)
@@ -56,10 +58,11 @@ class Client : ClientInterface {
                 this,
                 sessionStorageConfig.legacyClientId,
                 sessionStorageConfig.legacyClientSecret,
-                sessionStorageConfig.legacySharedPrefsFilename
+                sessionStorageConfig.legacySharedPrefsFilename,
+                eventListener
             )
         } else {
-            EncryptedSharedPrefsStorage(context.applicationContext)
+            EncryptedSharedPrefsStorage(context.applicationContext, eventListener)
         }
 
         schibstedAccountApi =

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/listener/EncryptedSharedPreferencesEventListener.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/listener/EncryptedSharedPreferencesEventListener.kt
@@ -7,7 +7,7 @@ import java.security.GeneralSecurityException
  * One of the teams has a strange issue with user being logged out
  * and they suspect the androidx.crypto library might be the reason.
  */
-abstract class WebFlowsEventListener {
+abstract class EncryptedSharedPreferencesEventListener {
 
     open fun preferencesReadStart() {}
 
@@ -23,10 +23,10 @@ abstract class WebFlowsEventListener {
 
     open fun deletePreferencesEnd() {}
 
-    open fun deletePreferencesError() {}
+    open fun deletePreferencesError(e: Exception) {}
 
 
     companion object {
-        val NONE = object : WebFlowsEventListener() {}
+        val NONE = object : EncryptedSharedPreferencesEventListener() {}
     }
 }

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/listener/WebFlowsEventListener.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/listener/WebFlowsEventListener.kt
@@ -2,6 +2,11 @@ package com.schibsted.account.webflows.client.listener
 
 import java.security.GeneralSecurityException
 
+/**
+ * An event listener for the creation of the encrypted preferences.
+ * One of the teams has a strange issue with user being logged out
+ * and they suspect the androidx.crypto library might be the reason.
+ */
 abstract class WebFlowsEventListener {
 
     open fun preferencesReadStart() {}

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/listener/WebFlowsEventListener.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/listener/WebFlowsEventListener.kt
@@ -1,0 +1,27 @@
+package com.schibsted.account.webflows.client.listener
+
+import java.security.GeneralSecurityException
+
+abstract class WebFlowsEventListener {
+
+    open fun preferencesReadStart() {}
+
+    open fun preferencesReadEnd() {}
+
+    open fun createEncryptedSharedPreferences() {}
+
+    open fun createEncryptedSharedPreferencesFailure(e: GeneralSecurityException) {}
+
+    open fun preferencesReadError(e: SecurityException) {}
+
+    open fun deletePreferencesStart() {}
+
+    open fun deletePreferencesEnd() {}
+
+    open fun deletePreferencesError() {}
+
+
+    companion object {
+        val NONE = object : WebFlowsEventListener() {}
+    }
+}

--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
@@ -7,7 +7,7 @@ import androidx.security.crypto.MasterKey
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonSyntaxException
-import com.schibsted.account.webflows.client.listener.WebFlowsEventListener
+import com.schibsted.account.webflows.client.listener.EncryptedSharedPreferencesEventListener
 import com.schibsted.account.webflows.user.StoredUserSession
 import timber.log.Timber
 import java.io.File
@@ -28,7 +28,7 @@ internal interface SessionStorage {
 
 internal class EncryptedSharedPrefsStorage(
     val context: Context,
-    private val eventListener: WebFlowsEventListener
+    private val eventListener: EncryptedSharedPreferencesEventListener
 ) : SessionStorage {
     private val gson = GsonBuilder().setDateFormat("MM dd, yyyy HH:mm:ss").create()
 
@@ -127,7 +127,7 @@ internal class EncryptedSharedPrefsStorage(
             eventListener.deletePreferencesEnd()
             Timber.d("Finished deleting encrypted shared preferences")
         } catch (e: Exception) {
-            eventListener.deletePreferencesError()
+            eventListener.deletePreferencesError(e)
             Timber.e("Error occurred while trying to delete encrypted shared preferences", e)
         }
     }

--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/compat/MigratingSessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/compat/MigratingSessionStorage.kt
@@ -3,6 +3,7 @@ package com.schibsted.account.webflows.persistence.compat
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.schibsted.account.webflows.client.Client
+import com.schibsted.account.webflows.client.listener.WebFlowsEventListener
 import com.schibsted.account.webflows.persistence.EncryptedSharedPrefsStorage
 import com.schibsted.account.webflows.persistence.SessionStorage
 import com.schibsted.account.webflows.user.MigrationStoredUserSession
@@ -14,7 +15,7 @@ internal class MigratingSessionStorage(
     private val newStorage: SessionStorage,
     private val legacyStorage: LegacySessionStorage,
     private val legacyClientId: String,
-    private val legacyClientSecret: String
+    private val legacyClientSecret: String,
 ) : SessionStorage {
 
     internal constructor(
@@ -22,13 +23,14 @@ internal class MigratingSessionStorage(
         client: Client,
         legacyClientId: String,
         legacyClientSecret: String,
-        legacySharedPrefsFilename: String?
+        legacySharedPrefsFilename: String?,
+        eventListener: WebFlowsEventListener
     ) : this(
         client,
-        EncryptedSharedPrefsStorage(context),
+        EncryptedSharedPrefsStorage(context, eventListener),
         LegacySessionStorage(context, legacySharedPrefsFilename),
         legacyClientId,
-        legacyClientSecret
+        legacyClientSecret,
     )
 
     override fun save(session: StoredUserSession) {

--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/compat/MigratingSessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/compat/MigratingSessionStorage.kt
@@ -3,7 +3,7 @@ package com.schibsted.account.webflows.persistence.compat
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.schibsted.account.webflows.client.Client
-import com.schibsted.account.webflows.client.listener.WebFlowsEventListener
+import com.schibsted.account.webflows.client.listener.EncryptedSharedPreferencesEventListener
 import com.schibsted.account.webflows.persistence.EncryptedSharedPrefsStorage
 import com.schibsted.account.webflows.persistence.SessionStorage
 import com.schibsted.account.webflows.user.MigrationStoredUserSession
@@ -24,7 +24,7 @@ internal class MigratingSessionStorage(
         legacyClientId: String,
         legacyClientSecret: String,
         legacySharedPrefsFilename: String?,
-        eventListener: WebFlowsEventListener
+        eventListener: EncryptedSharedPreferencesEventListener
     ) : this(
         client,
         EncryptedSharedPrefsStorage(context, eventListener),


### PR DESCRIPTION
This PR contains an event listener for the creation of the EncryptedShared preferences.

We suspect `androidx.crypto` is causing issues and the preferences are silently recreated which causes the logged-out state for the users. We would love to know more, about what's actually happening.

This change should be backward compatible and not cause any builds to be broken. A default no-op event listener instance is provided as a default param.

The `LoggingEventListener` is just a sample class to show how we can use the listener to get more info about what's happening.