### PR TITLE
Revert "feature/143 Change shared preference to be mutable and support being rebuilt"

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
@@ -25,33 +25,15 @@ internal interface SessionStorage {
     fun remove(clientId: String)
 }
 
-internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorage {
+internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
     private val gson = GsonBuilder().setDateFormat("MM dd, yyyy HH:mm:ss").create()
 
-    private var _sharedPreferences: SharedPreferences? = null
-
-    /**
-     * Returns the shared preferences.
-     *
-     * This method will check if the shared preferences has been initialized and takes the
-     * appropriate action.
-     *
-     * The shared preferences needs to be mutable as corrupted data can occur and then it needs
-     * to be purged and rebuilt.
-     */
-    @Synchronized
-    private fun getSharedPreferences(): SharedPreferences? {
-        if (_sharedPreferences != null) {
-            return _sharedPreferences
-        }
-
-        setupSharedPreferences(context)
-
-        return _sharedPreferences
+    private val prefs: SharedPreferences by lazy {
+        getSharedPreferences(context)
     }
 
     /**
-     * Setup the encrypted shared preferences.
+     * Gets the encrypted shared preferences.
      *
      * This method will try and build the encrypted shared preferences, and in case of an error,
      * it will delete the existing file from the filesystem and attempt to recreate it.
@@ -59,14 +41,14 @@ internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorag
      * A layer of thread safeness is needed to be sure the shared preferences is only accessed
      * by one invoker at a time, to reduce potential corruption.
      */
-    private fun setupSharedPreferences(context: Context) {
-        _sharedPreferences = try {
+    @Synchronized
+    private fun getSharedPreferences(context: Context): SharedPreferences {
+        return try {
             buildSharedPreferences(context)
         } catch (e: GeneralSecurityException) {
-            Timber.e(
-                "Error occurred while trying to build shared preferences, trying to recover",
-                e
-            )
+            e.printStackTrace()
+
+            Timber.e("Error occurred while trying to build shared preferences, trying to recover", e)
 
             deleteSharedPreferences(context)
 
@@ -100,8 +82,7 @@ internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorag
         Timber.d("Trying to delete encrypted shared preferences")
 
         try {
-            val sharedPreferencesFile =
-                File(context.filesDir?.parent + "/shared_prefs/" + PREFERENCE_FILENAME + ".xml")
+            val sharedPreferencesFile = File(context.filesDir?.parent + "/shared_prefs/" + PREFERENCE_FILENAME + ".xml")
 
             Timber.d("Shared preferences location: ${sharedPreferencesFile.absolutePath}")
 
@@ -121,35 +102,14 @@ internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorag
 
             Timber.d("Finished deleting encrypted shared preferences")
         } catch (e: Exception) {
+            e.printStackTrace()
+
             Timber.e("Error occurred while trying to delete encrypted shared preferences", e)
         }
     }
 
     @Synchronized
     override fun save(session: StoredUserSession) {
-        val prefs = getSharedPreferences()
-            ?: throw IllegalStateException("Shared preferences has not been initialized")
-
-        try {
-            internalSave(prefs, session)
-        } catch (e: SecurityException) {
-            Timber.e(
-                "Error occurred while trying to save data to the encrypted shared preferences, trying to recover (saving the data again)",
-                e
-            )
-
-            deleteSharedPreferences(context)
-
-            setupSharedPreferences(context)
-
-            val rebuiltPrefs = getSharedPreferences()
-                ?: throw IllegalStateException("Shared preferences has not been initialized")
-
-            internalSave(rebuiltPrefs, session)
-        }
-    }
-
-    private fun internalSave(prefs: SharedPreferences, session: StoredUserSession) {
         val editor = prefs.edit()
         val json = gson.toJson(session)
         editor.putString(session.clientId, json)
@@ -158,25 +118,8 @@ internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorag
 
     @Synchronized
     override fun get(clientId: String, callback: (StoredUserSession?) -> Unit) {
-        val prefs = getSharedPreferences()
-            ?: throw IllegalStateException("Shared preferences has not been initialized")
-
-        try {
-            val json = prefs.getString(clientId, null) ?: return callback(null)
-
-            callback(gson.getStoredUserSession(json) ?: Gson().getStoredUserSession(json))
-        } catch (e: SecurityException) {
-            Timber.e(
-                "Error occurred while trying to get data from the encrypted shared preferences, trying to recover (returning null)",
-                e
-            )
-
-            deleteSharedPreferences(context)
-
-            setupSharedPreferences(context)
-
-            callback(null)
-        }
+        val json = prefs.getString(clientId, null) ?: return callback(null)
+        callback(gson.getStoredUserSession(json) ?: Gson().getStoredUserSession(json))
     }
 
     private fun Gson.getStoredUserSession(json: String): StoredUserSession? {
@@ -189,23 +132,9 @@ internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorag
 
     @Synchronized
     override fun remove(clientId: String) {
-        val prefs = getSharedPreferences()
-            ?: throw IllegalStateException("Shared preferences has not been initialized")
-
-        try {
-            val editor = prefs.edit()
-            editor.remove(clientId)
-            editor.apply()
-        } catch (e: SecurityException) {
-            Timber.e(
-                "Error occurred while trying to remove data from the encrypted shared preferences, trying to recover (purging all)",
-                e
-            )
-
-            deleteSharedPreferences(context)
-
-            setupSharedPreferences(context)
-        }
+        val editor = prefs.edit()
+        editor.remove(clientId)
+        editor.apply()
     }
 
     companion object {


### PR DESCRIPTION
This PR is likely the cause of the unexpected logout on Android issue that is discussed in this [slack channel ](https://sch-chat.slack.com/archives/C03GWB06JL9) at the time of writing this PR. 

Before this PR the app would crash if the shared preferences were corrupted. After this PR the users would be logged out when the shared preferences were recreated. 

While we find a fix for having corrupted shared preferences product has decided that it is better that we go back to the crashing behaviour. Let's revert the PR and make a new release.