### PR TITLE
Revert logout on storage failure

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
@@ -49,7 +49,7 @@ class AuthResultLiveData private constructor(private val client: Client) :
                     }
                 }
                 .left().foreach {
-                    Left(NotAuthed.NoLoggedInUser)
+                    value = Left(NotAuthed.NoLoggedInUser)
                 }
         }
     }

--- a/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
@@ -19,6 +19,7 @@ sealed class NotAuthed {
 
 
 typealias AuthResult = Either<NotAuthed, User>
+
 /**
  * Holds current logged-in state of user.
  *
@@ -38,12 +39,18 @@ class AuthResultLiveData private constructor(private val client: Client) :
     }
 
     init {
-        client.resumeLastLoggedInUser { resumedUser ->
-            value = if (resumedUser != null) {
-                Right(resumedUser)
-            } else {
-                Left(NotAuthed.NoLoggedInUser)
-            }
+        client.resumeLastLoggedInUser { result ->
+            result
+                .foreach { resumedUser ->
+                    value = if (resumedUser != null) {
+                        Right(resumedUser)
+                    } else {
+                        Left(NotAuthed.NoLoggedInUser)
+                    }
+                }
+                .left().foreach {
+                    Left(NotAuthed.NoLoggedInUser)
+                }
         }
     }
 

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/ClientInterface.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/ClientInterface.kt
@@ -3,7 +3,9 @@ package com.schibsted.account.webflows.client
 import android.content.Context
 import android.content.Intent
 import com.schibsted.account.webflows.activities.AuthorizationManagementActivity
+import com.schibsted.account.webflows.persistence.StorageError
 import com.schibsted.account.webflows.user.User
+import com.schibsted.account.webflows.util.Either
 
 interface ClientInterface {
     /**
@@ -31,5 +33,5 @@ interface ClientInterface {
     fun handleAuthenticationResponse(intent: Intent, callback: LoginResultHandler)
 
     /** Resume any previously logged-in user session */
-    fun resumeLastLoggedInUser(callback: (User?) -> Unit)
+    fun resumeLastLoggedInUser(callback: (Either<StorageError, User?>) -> Unit)
 }

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/RetrofitClient.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/RetrofitClient.kt
@@ -48,7 +48,7 @@ class RetrofitClient<S>(
                 }
                 .left().foreach {
                     reset()
-                    callback(Either.Right(null))
+                    callback(Either.Left(it))
                 }
         }
     }

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/RetrofitClient.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/RetrofitClient.kt
@@ -1,5 +1,6 @@
 package com.schibsted.account.webflows.client
 
+import com.schibsted.account.webflows.persistence.StorageError
 import com.schibsted.account.webflows.token.UserTokens
 import com.schibsted.account.webflows.user.User
 import com.schibsted.account.webflows.util.Either
@@ -22,27 +23,33 @@ class RetrofitClient<S>(
      * This should ideally only be used on app startup
      * User will only be updated with new user if resumedUser contains a new user
      * */
-    override fun resumeLastLoggedInUser(callback: (User?) -> Unit) {
-        internalClient.resumeLastLoggedInUser { resumedUser ->
-            when {
-                user?.equals(resumedUser) == true -> {
-                    callback(user)
-                }
-                resumedUser != null -> {
-                    user = resumedUser
-                    retrofitApi = retrofitBuilder
-                        .client(resumedUser.httpClient)
-                        .build()
-                        .create(serviceClass)
+    override fun resumeLastLoggedInUser(callback: (Either<StorageError, User?>) -> Unit) {
+        internalClient.resumeLastLoggedInUser { result ->
+            result
+                .foreach { resumedUser: User? ->
+                    when {
+                        user?.equals(resumedUser) == true -> {
+                            callback(Either.Right(user))
+                        }
+                        resumedUser != null -> {
+                            user = resumedUser
+                            retrofitApi = retrofitBuilder
+                                .client(resumedUser.httpClient)
+                                .build()
+                                .create(serviceClass)
 
-                    callback(resumedUser)
+                            callback(Either.Right(resumedUser))
+                        }
+                        else -> {
+                            reset()
+                            callback(Either.Right(null))
+                        }
+                    }
                 }
-                else -> {
-                    user = null
-                    retrofitApi = null
-                    callback(null)
+                .left().foreach {
+                    reset()
+                    callback(Either.Right(null))
                 }
-            }
         }
     }
 
@@ -76,5 +83,10 @@ class RetrofitClient<S>(
 
     internal fun refreshTokensForUser(user: User): Either<RefreshTokenError, UserTokens> {
         return internalClient.refreshTokensForUser(user)
+    }
+
+    private fun reset() {
+        user = null
+        retrofitApi = null
     }
 }

--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
@@ -8,10 +8,6 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonSyntaxException
 import com.schibsted.account.webflows.user.StoredUserSession
-import timber.log.Timber
-import java.io.File
-import java.security.GeneralSecurityException
-import java.security.KeyStore
 
 /**
  * User session storage.
@@ -29,41 +25,11 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
     private val gson = GsonBuilder().setDateFormat("MM dd, yyyy HH:mm:ss").create()
 
     private val prefs: SharedPreferences by lazy {
-        getSharedPreferences(context)
-    }
-
-    /**
-     * Gets the encrypted shared preferences.
-     *
-     * This method will try and build the encrypted shared preferences, and in case of an error,
-     * it will delete the existing file from the filesystem and attempt to recreate it.
-     *
-     * A layer of thread safeness is needed to be sure the shared preferences is only accessed
-     * by one invoker at a time, to reduce potential corruption.
-     */
-    @Synchronized
-    private fun getSharedPreferences(context: Context): SharedPreferences {
-        return try {
-            buildSharedPreferences(context)
-        } catch (e: GeneralSecurityException) {
-            e.printStackTrace()
-
-            Timber.e("Error occurred while trying to build shared preferences, trying to recover", e)
-
-            deleteSharedPreferences(context)
-
-            buildSharedPreferences(context)
-        }
-    }
-
-    private fun buildSharedPreferences(context: Context): SharedPreferences {
-        Timber.d("Building the encrypted shared preferences")
-
         val masterKey = MasterKey.Builder(context.applicationContext)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build()
 
-        return EncryptedSharedPreferences.create(
+        EncryptedSharedPreferences.create(
             context.applicationContext,
             PREFERENCE_FILENAME,
             masterKey,
@@ -72,43 +38,6 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
         )
     }
 
-    /**
-     * Deletes the encrypted shared preferences.
-     *
-     * This method will try and find the actual shared preferences xml file and delete it. It
-     * will also try to delete the master key entry in the keystore.
-     */
-    private fun deleteSharedPreferences(context: Context) {
-        Timber.d("Trying to delete encrypted shared preferences")
-
-        try {
-            val sharedPreferencesFile = File(context.filesDir?.parent + "/shared_prefs/" + PREFERENCE_FILENAME + ".xml")
-
-            Timber.d("Shared preferences location: ${sharedPreferencesFile.absolutePath}")
-
-            if (sharedPreferencesFile.exists()) {
-                val deleted = sharedPreferencesFile.delete()
-
-                Timber.d("deleteSharedPreferences() Shared prefs file deleted: $deleted; path: ${sharedPreferencesFile.absolutePath}")
-            } else {
-                Timber.d("deleteSharedPreferences() Shared prefs file non-existent; path: ${sharedPreferencesFile.absolutePath}")
-            }
-
-            Timber.d("Deleting master key entry in keystore")
-
-            val keyStore = KeyStore.getInstance("AndroidKeyStore")
-            keyStore.load(null)
-            keyStore.deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
-
-            Timber.d("Finished deleting encrypted shared preferences")
-        } catch (e: Exception) {
-            e.printStackTrace()
-
-            Timber.e("Error occurred while trying to delete encrypted shared preferences", e)
-        }
-    }
-
-    @Synchronized
     override fun save(session: StoredUserSession) {
         val editor = prefs.edit()
         val json = gson.toJson(session)
@@ -116,7 +45,6 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
         editor.apply()
     }
 
-    @Synchronized
     override fun get(clientId: String, callback: (StoredUserSession?) -> Unit) {
         val json = prefs.getString(clientId, null) ?: return callback(null)
         callback(gson.getStoredUserSession(json) ?: Gson().getStoredUserSession(json))
@@ -130,7 +58,6 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
         }
     }
 
-    @Synchronized
     override fun remove(clientId: String) {
         val editor = prefs.edit()
         editor.remove(clientId)

--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
@@ -25,33 +25,15 @@ internal interface SessionStorage {
     fun remove(clientId: String)
 }
 
-internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorage {
+internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
     private val gson = GsonBuilder().setDateFormat("MM dd, yyyy HH:mm:ss").create()
 
-    private var _sharedPreferences: SharedPreferences? = null
-
-    /**
-     * Returns the shared preferences.
-     *
-     * This method will check if the shared preferences has been initialized and takes the
-     * appropriate action.
-     *
-     * The shared preferences needs to be mutable as corrupted data can occur and then it needs
-     * to be purged and rebuilt.
-     */
-    @Synchronized
-    private fun getSharedPreferences(): SharedPreferences? {
-        if (_sharedPreferences != null) {
-            return _sharedPreferences
-        }
-
-        setupSharedPreferences(context)
-
-        return _sharedPreferences
+    private val prefs: SharedPreferences by lazy {
+        getSharedPreferences(context)
     }
 
     /**
-     * Setup the encrypted shared preferences.
+     * Gets the encrypted shared preferences.
      *
      * This method will try and build the encrypted shared preferences, and in case of an error,
      * it will delete the existing file from the filesystem and attempt to recreate it.
@@ -59,14 +41,14 @@ internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorag
      * A layer of thread safeness is needed to be sure the shared preferences is only accessed
      * by one invoker at a time, to reduce potential corruption.
      */
-    private fun setupSharedPreferences(context: Context) {
-        _sharedPreferences = try {
+    @Synchronized
+    private fun getSharedPreferences(context: Context): SharedPreferences {
+        return try {
             buildSharedPreferences(context)
         } catch (e: GeneralSecurityException) {
-            Timber.e(
-                "Error occurred while trying to build shared preferences, trying to recover",
-                e
-            )
+            e.printStackTrace()
+
+            Timber.e("Error occurred while trying to build shared preferences, trying to recover", e)
 
             deleteSharedPreferences(context)
 
@@ -100,8 +82,7 @@ internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorag
         Timber.d("Trying to delete encrypted shared preferences")
 
         try {
-            val sharedPreferencesFile =
-                File(context.filesDir?.parent + "/shared_prefs/" + PREFERENCE_FILENAME + ".xml")
+            val sharedPreferencesFile = File(context.filesDir?.parent + "/shared_prefs/" + PREFERENCE_FILENAME + ".xml")
 
             Timber.d("Shared preferences location: ${sharedPreferencesFile.absolutePath}")
 
@@ -121,35 +102,14 @@ internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorag
 
             Timber.d("Finished deleting encrypted shared preferences")
         } catch (e: Exception) {
+            e.printStackTrace()
+
             Timber.e("Error occurred while trying to delete encrypted shared preferences", e)
         }
     }
 
     @Synchronized
     override fun save(session: StoredUserSession) {
-        val prefs = getSharedPreferences()
-            ?: throw IllegalStateException("Shared preferences has not been initialized")
-
-        try {
-            internalSave(prefs, session)
-        } catch (e: SecurityException) {
-            Timber.e(
-                "Error occurred while trying to save data to the encrypted shared preferences, trying to recover (saving the data again)",
-                e
-            )
-
-            deleteSharedPreferences(context)
-
-            setupSharedPreferences(context)
-
-            val rebuiltPrefs = getSharedPreferences()
-                ?: throw IllegalStateException("Shared preferences has not been initialized")
-
-            internalSave(rebuiltPrefs, session)
-        }
-    }
-
-    private fun internalSave(prefs: SharedPreferences, session: StoredUserSession) {
         val editor = prefs.edit()
         val json = gson.toJson(session)
         editor.putString(session.clientId, json)
@@ -158,25 +118,8 @@ internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorag
 
     @Synchronized
     override fun get(clientId: String, callback: (StoredUserSession?) -> Unit) {
-        val prefs = getSharedPreferences()
-            ?: throw IllegalStateException("Shared preferences has not been initialized")
-
-        try {
-            val json = prefs.getString(clientId, null) ?: return callback(null)
-
-            callback(gson.getStoredUserSession(json) ?: Gson().getStoredUserSession(json))
-        } catch (e: SecurityException) {
-            Timber.e(
-                "Error occurred while trying to get data from the encrypted shared preferences, trying to recover (returning null)",
-                e
-            )
-
-            deleteSharedPreferences(context)
-
-            setupSharedPreferences(context)
-
-            callback(null)
-        }
+        val json = prefs.getString(clientId, null) ?: return callback(null)
+        callback(gson.getStoredUserSession(json) ?: Gson().getStoredUserSession(json))
     }
 
     private fun Gson.getStoredUserSession(json: String): StoredUserSession? {
@@ -189,23 +132,9 @@ internal class EncryptedSharedPrefsStorage(val context: Context) : SessionStorag
 
     @Synchronized
     override fun remove(clientId: String) {
-        val prefs = getSharedPreferences()
-            ?: throw IllegalStateException("Shared preferences has not been initialized")
-
-        try {
-            val editor = prefs.edit()
-            editor.remove(clientId)
-            editor.apply()
-        } catch (e: SecurityException) {
-            Timber.e(
-                "Error occurred while trying to remove data from the encrypted shared preferences, trying to recover (purging all)",
-                e
-            )
-
-            deleteSharedPreferences(context)
-
-            setupSharedPreferences(context)
-        }
+        val editor = prefs.edit()
+        editor.remove(clientId)
+        editor.apply()
     }
 
     companion object {

--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/StorageError.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/StorageError.kt
@@ -1,0 +1,5 @@
+package com.schibsted.account.webflows.persistence
+
+sealed class StorageError {
+    data class UnexpectedError(val cause: Throwable): StorageError()
+}

--- a/webflows/src/test/java/com/schibsted/account/webflows/activities/AuthResultLiveDataTest.kt
+++ b/webflows/src/test/java/com/schibsted/account/webflows/activities/AuthResultLiveDataTest.kt
@@ -10,7 +10,9 @@ import com.schibsted.account.testutil.assertRight
 import com.schibsted.account.webflows.client.Client
 import com.schibsted.account.webflows.client.LoginError
 import com.schibsted.account.webflows.client.LoginResultHandler
+import com.schibsted.account.webflows.persistence.StorageError
 import com.schibsted.account.webflows.user.User
+import com.schibsted.account.webflows.util.Either
 import com.schibsted.account.webflows.util.Either.Left
 import com.schibsted.account.webflows.util.Either.Right
 import io.mockk.every
@@ -56,8 +58,8 @@ class AuthResultLiveDataTest {
         val client = mockk<Client>(relaxed = true)
         val user = User(client, Fixtures.userTokens)
         every { client.resumeLastLoggedInUser(any()) } answers {
-            val callback = firstArg<(User?) -> Unit>()
-            callback(user)
+            val callback = firstArg<(Either<StorageError, User?>) -> Unit>()
+            callback(Right(user))
         }
 
         AuthResultLiveData.create(client)
@@ -68,8 +70,8 @@ class AuthResultLiveDataTest {
     fun initResumesNoLoggedInUser() {
         val client = mockk<Client>(relaxed = true)
         every { client.resumeLastLoggedInUser(any()) } answers {
-            val callback = firstArg<(User?) -> Unit>()
-            callback(null)
+            val callback = firstArg<(Either<StorageError, User?>) -> Unit>()
+            callback(Right(null))
         }
 
         AuthResultLiveData.create(client)
@@ -119,8 +121,8 @@ class AuthResultLiveDataTest {
         val client = mockk<Client>(relaxed = true)
         val user = User(client, Fixtures.userTokens)
         every { client.resumeLastLoggedInUser(any()) } answers {
-            val callback = firstArg<(User?) -> Unit>()
-            callback(user)
+            val callback = firstArg<(Either<StorageError, User?>) -> Unit>()
+            callback(Right(user))
         }
         AuthResultLiveData.create(client)
 

--- a/webflows/src/test/java/com/schibsted/account/webflows/activities/AuthResultLiveDataTest.kt
+++ b/webflows/src/test/java/com/schibsted/account/webflows/activities/AuthResultLiveDataTest.kt
@@ -79,6 +79,18 @@ class AuthResultLiveDataTest {
     }
 
     @Test
+    fun initHandlesStorageError() {
+        val client = mockk<Client>(relaxed = true)
+        every { client.resumeLastLoggedInUser(any()) } answers {
+            val callback = firstArg<(Either<StorageError, User?>) -> Unit>()
+            callback(Left(StorageError.UnexpectedError(Exception("Something went wrong"))))
+        }
+
+        AuthResultLiveData.create(client)
+        AuthResultLiveData.get().value!!.assertLeft { assertEquals(NotAuthed.NoLoggedInUser, it) }
+    }
+
+    @Test
     fun updateHandlesSuccessResult() {
         val client = mockk<Client>(relaxed = true)
         val user = User(client, Fixtures.userTokens)

--- a/webflows/src/test/java/com/schibsted/account/webflows/client/RetrofitClientTest.kt
+++ b/webflows/src/test/java/com/schibsted/account/webflows/client/RetrofitClientTest.kt
@@ -14,6 +14,7 @@ import com.schibsted.account.webflows.api.HttpError
 import com.schibsted.account.webflows.api.UserTokenResponse
 import com.schibsted.account.webflows.persistence.SessionStorage
 import com.schibsted.account.webflows.persistence.StateStorage
+import com.schibsted.account.webflows.persistence.StorageReadCallback
 import com.schibsted.account.webflows.token.TokenError
 import com.schibsted.account.webflows.token.TokenHandler
 import com.schibsted.account.webflows.token.TokenRequestResult
@@ -144,16 +145,18 @@ class RetrofitClientTest {
         val userSession = StoredUserSession(clientConfig.clientId, Fixtures.userTokens, Date())
         val sessionStorageMock: SessionStorage = mockk(relaxUnitFun = true)
         every { sessionStorageMock.get(clientConfig.clientId, any()) } answers {
-            val callback = secondArg<(StoredUserSession?) -> Unit>()
-            callback(userSession)
+            val callback = secondArg<StorageReadCallback>()
+            callback(Right(userSession))
         }
         val client = getRetrofitClient(Fixtures.getClient(sessionStorage = sessionStorageMock))
 
         client.resumeLastLoggedInUser { result ->
-            assertEquals(
-                User(client.internalClient, UserSession(Fixtures.userTokens)),
-                result
-            )
+            result.assertRight {
+                assertEquals(
+                    User(client.internalClient, UserSession(Fixtures.userTokens)),
+                    it
+                )
+            }
         }
     }
 
@@ -171,16 +174,18 @@ class RetrofitClientTest {
         val userSession = StoredUserSession(clientConfig.clientId, Fixtures.userTokens, Date())
         val sessionStorageMock: SessionStorage = mockk(relaxUnitFun = true)
         every { sessionStorageMock.get(clientConfig.clientId, any()) } answers {
-            val callback = secondArg<(StoredUserSession?) -> Unit>()
-            callback(userSession)
+            val callback = secondArg<StorageReadCallback>()
+            callback(Right(userSession))
         }
         val client = getRetrofitClient(Fixtures.getClient(sessionStorage = sessionStorageMock))
 
         client.resumeLastLoggedInUser { result ->
-            assertEquals(
-                User(client.internalClient, UserSession(Fixtures.userTokens)),
-                result
-            )
+            result.assertRight {
+                assertEquals(
+                    User(client.internalClient, UserSession(Fixtures.userTokens)),
+                    it
+                )
+            }
         }
 
         val result = client.isInitialized()

--- a/webflows/src/test/java/com/schibsted/account/webflows/client/RetrofitClientTest.kt
+++ b/webflows/src/test/java/com/schibsted/account/webflows/client/RetrofitClientTest.kt
@@ -14,6 +14,7 @@ import com.schibsted.account.webflows.api.HttpError
 import com.schibsted.account.webflows.api.UserTokenResponse
 import com.schibsted.account.webflows.persistence.SessionStorage
 import com.schibsted.account.webflows.persistence.StateStorage
+import com.schibsted.account.webflows.persistence.StorageError
 import com.schibsted.account.webflows.persistence.StorageReadCallback
 import com.schibsted.account.webflows.token.TokenError
 import com.schibsted.account.webflows.token.TokenHandler
@@ -22,12 +23,10 @@ import com.schibsted.account.webflows.token.UserTokensResult
 import com.schibsted.account.webflows.user.StoredUserSession
 import com.schibsted.account.webflows.user.User
 import com.schibsted.account.webflows.user.UserSession
+import com.schibsted.account.webflows.util.Either
 import com.schibsted.account.webflows.util.Either.Left
 import com.schibsted.account.webflows.util.Either.Right
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.verify
+import io.mockk.*
 import org.junit.Assert.*
 import org.junit.BeforeClass
 import org.junit.Test
@@ -158,6 +157,23 @@ class RetrofitClientTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun storageErrorIsPropagatedToCallback() {
+        val sessionStorageMock: SessionStorage = mockk(relaxUnitFun = true)
+        val error = StorageError.UnexpectedError(Exception("Something went wrong"))
+        every { sessionStorageMock.get(clientConfig.clientId, any()) } answers {
+            val callback = secondArg<StorageReadCallback>()
+            callback(Left(error))
+        }
+        val client = getRetrofitClient(Fixtures.getClient(sessionStorage = sessionStorageMock))
+
+        val resultCallback = mockk<(Either<StorageError, User?>) -> Unit>()
+        every { resultCallback(any()) } just Runs
+
+        client.resumeLastLoggedInUser(resultCallback)
+        verify(exactly = 1) { resultCallback(Left(error)) }
     }
 
     @Test

--- a/webflows/src/test/java/com/schibsted/account/webflows/user/UserTest.kt
+++ b/webflows/src/test/java/com/schibsted/account/webflows/user/UserTest.kt
@@ -13,9 +13,11 @@ import com.schibsted.account.webflows.api.UserTokenResponse
 import com.schibsted.account.webflows.client.Client
 import com.schibsted.account.webflows.client.RefreshTokenError
 import com.schibsted.account.webflows.persistence.SessionStorage
+import com.schibsted.account.webflows.persistence.StorageError
 import com.schibsted.account.webflows.token.TokenError
 import com.schibsted.account.webflows.token.TokenHandler
 import com.schibsted.account.webflows.token.UserTokens
+import com.schibsted.account.webflows.util.Either
 import com.schibsted.account.webflows.util.Either.Left
 import com.schibsted.account.webflows.util.Either.Right
 import io.mockk.every
@@ -338,8 +340,8 @@ class UserTest {
         val client = mockk<Client>(relaxed = true)
         val user = User(client, Fixtures.userTokens)
         every { client.resumeLastLoggedInUser(any()) } answers {
-            val callback = firstArg<(User?) -> Unit>()
-            callback(user)
+            val callback = firstArg<(Either<StorageError, User?>) -> Unit>()
+            callback(Right(user))
         }
         AuthResultLiveData.create(client)
 


### PR DESCRIPTION
Handle possible exceptions in EncryptedSharedPrefsStorage:
Log the error and in case of read operation, propagate the error to the
caller (to be able to signal problem resuming user session).