### PR TITLE
Don't attempt to parse error objects from 5xx responses

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -285,7 +285,7 @@ data class OAuthError(val error: String, val errorDescription: String?) {
 }
 
 private fun TokenError.toOauthError(): OAuthError? {
-    if (this is TokenError.TokenRequestError && cause is HttpError.ErrorResponse && cause.body != null) {
+    if (this is TokenError.TokenRequestError && cause is HttpError.ErrorResponse && cause.code !in 500..504 && cause.body != null) {
         return OAuthError.fromJson(cause.body)
     }
 


### PR DESCRIPTION
Cloudflare returns either 502 or 504 with an HTML page when we have server outages. This PR fixes the crash that occurs when we have outages