### PR TITLE
Revert recreating the encrypted token storage on initialisation error.

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/persistence/SessionStorage.kt
@@ -10,7 +10,9 @@ import com.google.gson.JsonSyntaxException
 import com.schibsted.account.webflows.user.StoredUserSession
 import com.schibsted.account.webflows.util.Either
 import timber.log.Timber
+import java.io.File
 import java.security.GeneralSecurityException
+import java.security.KeyStore
 
 internal typealias StorageReadCallback = (Either<StorageError, StoredUserSession?>) -> Unit
 
@@ -30,24 +32,71 @@ internal class EncryptedSharedPrefsStorage(context: Context) : SessionStorage {
     private val gson = GsonBuilder().setDateFormat("MM dd, yyyy HH:mm:ss").create()
 
     private val prefs: SharedPreferences by lazy {
+        getSharedPreferences(context)
+    }
+
+    /**
+     * Gets the encrypted shared preferences.
+     *
+     * This method will try and build the encrypted shared preferences, and in case of an error,
+     * it will delete the existing file from the filesystem and attempt to recreate it.
+     *
+     * A layer of thread safeness is needed to be sure the shared preferences is only accessed
+     * by one invoker at a time, to reduce potential corruption.
+     */
+    @Synchronized
+    private fun getSharedPreferences(context: Context): SharedPreferences {
+        return try {
+            buildSharedPreferences(context)
+        } catch (e: GeneralSecurityException) {
+            Timber.e("Error occurred while trying to build shared preferences, trying to recover", e)
+
+            deleteSharedPreferences(context)
+            buildSharedPreferences(context)
+        }
+    }
+
+    private fun buildSharedPreferences(context: Context): SharedPreferences {
+        Timber.d("Building the encrypted shared preferences")
+
         val masterKey = MasterKey.Builder(context.applicationContext)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build()
 
+        return EncryptedSharedPreferences.create(
+            context.applicationContext,
+            PREFERENCE_FILENAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    private fun deleteSharedPreferences(context: Context) {
+        Timber.d("Trying to delete encrypted shared preferences")
+
         try {
-            EncryptedSharedPreferences.create(
-                context.applicationContext,
-                PREFERENCE_FILENAME,
-                masterKey,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            )
-        } catch (e: GeneralSecurityException) {
-            Timber.e(
-                "Error occurred while trying to build encrypted shared preferences",
-                e
-            )
-            throw e
+            val sharedPreferencesFile = File(context.filesDir?.parent + "/shared_prefs/" + PREFERENCE_FILENAME + ".xml")
+
+            Timber.d("Shared preferences location: ${sharedPreferencesFile.absolutePath}")
+
+            if (sharedPreferencesFile.exists()) {
+                val deleted = sharedPreferencesFile.delete()
+
+                Timber.d("deleteSharedPreferences() Shared prefs file deleted: $deleted; path: ${sharedPreferencesFile.absolutePath}")
+            } else {
+                Timber.d("deleteSharedPreferences() Shared prefs file non-existent; path: ${sharedPreferencesFile.absolutePath}")
+            }
+
+            Timber.d("Deleting master key entry in keystore")
+
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            keyStore.deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+
+            Timber.d("Finished deleting encrypted shared preferences")
+        } catch (e: Exception) {
+            Timber.e("Error occurred while trying to delete encrypted shared preferences", e)
         }
     }
 


### PR DESCRIPTION
If the EncryptedSharedPreferences can't be created, try to delete the existing file and delete the master key.
See https://github.com/google/tink/issues/535 for more info.

This might happen when a user uninstalls an app using this SDK, and then re-installs the app again.

_Follow up of https://github.com/schibsted/account-sdk-android-web/pull/50 and related to https://github.com/schibsted/account-sdk-android-web/issues/48._