### PR TITLE
Fix resume of authorization management activity

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthorizationManagementActivity.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthorizationManagementActivity.kt
@@ -112,7 +112,7 @@ class AuthorizationManagementActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val bundle = intent.extras ?: savedInstanceState
+        val bundle = savedInstanceState ?: intent.extras
         if (bundle != null) {
             // We're either first starting this activity or resuming it after completed auth
             extractState(bundle)

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -88,9 +88,10 @@ class Client : ClientInterface {
     override fun getAuthenticationIntent(context: Context, authRequest: AuthRequest): Intent {
         val loginUrl = generateLoginUrl(authRequest)
         val intent: Intent = if (this.isCustomTabsSupported(context)) {
-            CustomTabsIntent.Builder().build().apply {
-                intent.data = loginUrl
-            }.intent
+            buildCustomTabsIntent()
+                .apply {
+                    intent.data = loginUrl
+                }.intent
         } else {
             Intent(Intent.ACTION_VIEW, loginUrl).addCategory(Intent.CATEGORY_BROWSABLE)
         }
@@ -106,13 +107,16 @@ class Client : ClientInterface {
     override fun launchAuth(context: Context, authRequest: AuthRequest) {
         val loginUrl = generateLoginUrl(authRequest)
         if (this.isCustomTabsSupported(context)) {
-            CustomTabsIntent.Builder()
-                .build()
-                .launchUrl(context, loginUrl)
+            buildCustomTabsIntent().launchUrl(context, loginUrl)
         } else {
             val intent = Intent(Intent.ACTION_VIEW, loginUrl).addCategory(Intent.CATEGORY_BROWSABLE)
             context.startActivity(intent)
         }
+    }
+
+    private fun buildCustomTabsIntent(): CustomTabsIntent {
+        return CustomTabsIntent.Builder()
+            .build()
     }
 
     private fun generateLoginUrl(authRequest: AuthRequest): Uri {


### PR DESCRIPTION
### Description

If the `AuthorizationManagementActivity` is killed, the login flow would be continuously restarted as the `savedInstanceState` was not used when the activity resumed (hence ignoring the value of `authStarted`).

### Testing instructions
1. Update device settings: In "Developer Options", enable "Don't keep activities"
2. Start the example app.
3. Start the login flow and complete it.
4. Verify you end up back in the app as successfully logged-in.