### PR TITLE
Fix RetrofitClient: update reference to user on every new login.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ implementation 'com.schibsted.account:account-sdk-android-web:<version>'
    )
    ```
 
+   Then use this `RetrofitClient` instance as a replacement in all places where a `Client`
+   object is expected below.
+
 3. Initialise `AuthorizationManagementActivity` on app startup (see
    [ExampleApp](https://github.schibsted.io/spt-identity/account-sdk-android-web/blob/master/app/src/main/java/com/schibsted/account/example/ExampleApp.kt)
    as reference):

--- a/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import androidx.annotation.MainThread
 import androidx.lifecycle.LiveData
 import com.schibsted.account.webflows.client.Client
+import com.schibsted.account.webflows.client.ClientInterface
 import com.schibsted.account.webflows.client.LoginError
 import com.schibsted.account.webflows.user.User
 import com.schibsted.account.webflows.util.Either
@@ -31,7 +32,7 @@ typealias AuthResult = Either<NotAuthed, User>
  *   3. Auth flow cancelled: Failure(NotAuthed.CancelledByUser)
  *   4. User logs out: Failure(NotAuthed.NoLoggedInUser)
  */
-class AuthResultLiveData private constructor(private val client: Client) :
+class AuthResultLiveData private constructor(private val client: ClientInterface) :
     LiveData<AuthResult>() {
 
     internal fun update(result: AuthResult) {
@@ -83,7 +84,7 @@ class AuthResultLiveData private constructor(private val client: Client) :
 
         @JvmStatic
         @MainThread
-        internal fun create(client: Client): AuthResultLiveData {
+        internal fun create(client: ClientInterface): AuthResultLiveData {
             if (::instance.isInitialized) {
                 throw IllegalStateException("Already initialized")
             }

--- a/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthorizationManagementActivity.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthorizationManagementActivity.kt
@@ -34,6 +34,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import com.schibsted.account.webflows.client.Client
+import com.schibsted.account.webflows.client.ClientInterface
 import com.schibsted.account.webflows.util.Either.Left
 import timber.log.Timber
 
@@ -196,7 +197,7 @@ class AuthorizationManagementActivity : Activity() {
 
         @JvmStatic
         fun setup(
-            client: Client,
+            client: ClientInterface,
             completionIntent: PendingIntent? = null,
             cancelIntent: PendingIntent? = null
         ) {

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/RetrofitClient.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/RetrofitClient.kt
@@ -1,7 +1,7 @@
 package com.schibsted.account.webflows.client
 
+import android.content.Intent
 import com.schibsted.account.webflows.persistence.StorageError
-import com.schibsted.account.webflows.token.UserTokens
 import com.schibsted.account.webflows.user.User
 import com.schibsted.account.webflows.util.Either
 import retrofit2.Retrofit
@@ -81,8 +81,13 @@ class RetrofitClient<S>(
         return null
     }
 
-    internal fun refreshTokensForUser(user: User): Either<RefreshTokenError, UserTokens> {
-        return internalClient.refreshTokensForUser(user)
+    override fun handleAuthenticationResponse(intent: Intent, callback: LoginResultHandler) {
+        internalClient.handleAuthenticationResponse(intent) { loginResult: Either<LoginError, User> ->
+            loginResult
+                .onSuccess { this.user = it }
+                .onFailure { this.reset() }
+            callback(loginResult)
+        }
     }
 
     private fun reset() {


### PR DESCRIPTION
To support users logging in, not being resumed from existing storage.

## Testing instructions
1. Create a  `RetrofitClient` instance.
1. Test the "automatic" flow
   1. Pass the `RetrofitClient` to `AuthorizationManagementActivity.setup` (for example in `ExampleApp.kt`
   1. Verify the automatic resume of User via AuthResultLiveData works, and that `RetrofitClient.makeAuthenticatedRequest` works.
   1. Verify fresh login works: Trigger the login flow, and then switch user in the web flow to login as a different user. A new call to `RetrofitClient.makeAuthenticatedRequest` uses the tokens of the recently logged-in user.