### PR TITLE
Throw different error type if user cancels login

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
@@ -61,7 +61,7 @@ class AuthResultLiveData private constructor(private val client: Client) :
                 is Left -> update(
                     Left(
                         when (result.value) {
-                            is LoginError.CanceledByUser -> NotAuthed.CancelledByUser
+                            is LoginError.CancelledByUser -> NotAuthed.CancelledByUser
                             else -> NotAuthed.LoginFailed(result.value)
                         }
                     )

--- a/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
@@ -58,7 +58,14 @@ class AuthResultLiveData private constructor(private val client: Client) :
         client.handleAuthenticationResponse(intent) { result ->
             when (result) {
                 is Right -> update(result)
-                is Left -> update(Left(NotAuthed.LoginFailed(result.value)))
+                is Left -> update(
+                    Left(
+                        when (result.value) {
+                            is LoginError.CanceledByUser -> NotAuthed.CancelledByUser
+                            else -> NotAuthed.LoginFailed(result.value)
+                        }
+                    )
+                )
             }
         }
     }

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -172,7 +172,7 @@ class Client {
         val errorDescription = authResponse["error_description"]
         if (error != null && error == eidUserCancelError["error"] && errorDescription == eidUserCancelError["error_description"]) {
             val oauthError = OAuthError(error, errorDescription)
-            callback(Left(LoginError.CanceledByUser(oauthError)))
+            callback(Left(LoginError.CancelledByUser(oauthError)))
             return
         }
 
@@ -335,7 +335,7 @@ sealed class LoginError {
     data class TokenErrorResponse(val error: OAuthError) : LoginError()
 
     /** User canceled login. */
-    data class CanceledByUser(val error: OAuthError) : LoginError()
+    data class CancelledByUser(val error: OAuthError) : LoginError()
 
     /** Something went wrong. */
     data class UnexpectedError(val message: String) : LoginError()

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -28,7 +28,7 @@ import okhttp3.OkHttpClient
 import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
-import java.util.*
+import java.util.Date
 
 /**  Represents a client registered with Schibsted account. */
 class Client {
@@ -93,7 +93,10 @@ class Client {
      * @param authRequest Authentication request parameters.
      */
     @JvmOverloads
-    fun getAuthenticationIntent(context: Context, authRequest: AuthRequest = AuthRequest()): Intent {
+    fun getAuthenticationIntent(
+        context: Context,
+        authRequest: AuthRequest = AuthRequest()
+    ): Intent {
         val loginUrl = generateLoginUrl(authRequest)
         val intent: Intent = if (this.isCustomTabsSupported(context)) {
             buildCustomTabsIntent()
@@ -165,11 +168,23 @@ class Client {
             callback(Left(LoginError.UnsolicitedResponse))
             return
         }
+
+        val eidUserCancelError = mapOf(
+            "error" to "access_denied",
+            "error_description" to "EID authentication was canceled by the user"
+        )
+        val error = authResponse["error"]
+        val errorDescription = authResponse["error_description"]
+        if (error != null && error == eidUserCancelError["error"] && errorDescription == eidUserCancelError["error_description"]) {
+            val oauthError = OAuthError(error, errorDescription)
+            callback(Left(LoginError.CanceledByUser(oauthError)))
+            return
+        }
+
         stateStorage.removeValue(AUTH_STATE_KEY)
 
-        val error = authResponse["error"]
         if (error != null) {
-            val oauthError = OAuthError(error, authResponse["error_description"])
+            val oauthError = OAuthError(error, errorDescription)
             callback(Left(LoginError.AuthenticationErrorResponse(oauthError)))
             return
         }
@@ -260,6 +275,7 @@ class Client {
                     Left(RefreshTokenError.UnexpectedError("User has logged-out during token refresh"))
                 }
             }
+
             is Left -> {
                 Timber.e("Failed to refresh token: $result")
                 Left(RefreshTokenError.RefreshRequestFailed(result.value.cause))
@@ -317,6 +333,9 @@ sealed class LoginError {
      * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html#TokenErrorResponse" target="_top">Token Error Response</a>
      */
     data class TokenErrorResponse(val error: OAuthError) : LoginError()
+
+    /** User canceled login. */
+    data class CanceledByUser(val error: OAuthError) : LoginError()
 
     /** Something went wrong. */
     data class UnexpectedError(val message: String) : LoginError()

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -164,11 +164,6 @@ class Client {
         val stored = stateStorage.getValue(AUTH_STATE_KEY, AuthState::class)
             ?: return callback(Left(LoginError.AuthStateReadError))
 
-        if (stored.state != authResponse["state"]) {
-            callback(Left(LoginError.UnsolicitedResponse))
-            return
-        }
-
         val eidUserCancelError = mapOf(
             "error" to "access_denied",
             "error_description" to "EID authentication was canceled by the user"
@@ -178,6 +173,11 @@ class Client {
         if (error != null && error == eidUserCancelError["error"] && errorDescription == eidUserCancelError["error_description"]) {
             val oauthError = OAuthError(error, errorDescription)
             callback(Left(LoginError.CanceledByUser(oauthError)))
+            return
+        }
+
+        if (stored.state != authResponse["state"]) {
+            callback(Left(LoginError.UnsolicitedResponse))
             return
         }
 


### PR DESCRIPTION
If user cancels login flow (from eiD) we should return `NotAuthed.CancelledByUser` so that it can be handled separately by the mobile apps.

This will allow mobile apps to handle this case the same way as if user canceled login flow by closing the custom tabs.