### PR TITLE
5.0.1 - Throw different error type if user cancels login (#83)

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/activities/AuthResultLiveData.kt
@@ -58,7 +58,14 @@ class AuthResultLiveData private constructor(private val client: Client) :
         client.handleAuthenticationResponse(intent) { result ->
             when (result) {
                 is Right -> update(result)
-                is Left -> update(Left(NotAuthed.LoginFailed(result.value)))
+                is Left -> update(
+                    Left(
+                        when (result.value) {
+                            is LoginError.CancelledByUser -> NotAuthed.CancelledByUser
+                            else -> NotAuthed.LoginFailed(result.value)
+                        }
+                    )
+                )
             }
         }
     }


### PR DESCRIPTION
Complementary PR for https://github.com/schibsted/account-sdk-android-web/pull/83 but to branch started from 5.0.0 tag


* Throw different error type if user cancels login

* Check error before state

- throw NotAuthed.CancelledByUser error

* Fix typo

Fix for 5.0.0 version