### PR TITLE
Login prompt crash

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -302,7 +302,7 @@ class Client {
                     this.getAuthenticationIntent(context),
                     isCancelable
                 )
-            ).showLoginPrompt(supportFragmentManager)
+            ).showLoginPromptIfAbsent(supportFragmentManager)
         }
     }
 

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -296,8 +296,13 @@ class Client {
         supportFragmentManager: FragmentManager,
         isCancelable: Boolean = true
     ) {
-        if(userHasSessionOnDevice(context.applicationContext)) {
-            LoginPromptManager(LoginPromptConfig(this, isCancelable)).showLoginPrompt(supportFragmentManager)
+        if (userHasSessionOnDevice(context.applicationContext)) {
+            LoginPromptManager(
+                LoginPromptConfig(
+                    this.getAuthenticationIntent(context),
+                    isCancelable
+                )
+            ).showLoginPrompt(supportFragmentManager)
         }
     }
 

--- a/webflows/src/main/java/com/schibsted/account/webflows/loginPrompt/LoginPromptFragment.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/loginPrompt/LoginPromptFragment.kt
@@ -23,11 +23,11 @@ internal class LoginPromptFragment : BottomSheetDialogFragment() {
     private var _binding: LoginPromptBinding? = null
     private val binding get() = _binding!!
 
-    // TODO: look into not keeping a reference to loginPromptConfig inside loginPromptFragment
-    lateinit var loginPromptConfig: LoginPromptConfig
+    private lateinit var loginPromptConfig: LoginPromptConfig
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        loginPromptConfig = requireArguments().getParcelable(ARG_CONFIG)!!
         setStyle(STYLE_NORMAL, R.style.LoginPromptDialog)
 
         lifecycleScope.launch {
@@ -76,7 +76,7 @@ internal class LoginPromptFragment : BottomSheetDialogFragment() {
 
     private fun initializeButtons() {
         binding.loginPromptAuth.setOnClickListener {
-            startActivity(loginPromptConfig.client.getAuthenticationIntent(this.requireContext()))
+            startActivity(loginPromptConfig.authIntent)
             SchibstedAccountTracker.track(LoginPromptClickToLogin)
         }
         binding.loginPromptSkip.setOnClickListener {
@@ -99,4 +99,9 @@ internal class LoginPromptFragment : BottomSheetDialogFragment() {
             }
         }
     }
+
+    companion object {
+        const val ARG_CONFIG = "LOGIN_PROMPT_CONFIG_ARG"
+    }
+
 }

--- a/webflows/src/main/java/com/schibsted/account/webflows/loginPrompt/LoginPromptManager.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/loginPrompt/LoginPromptManager.kt
@@ -21,16 +21,13 @@ internal class LoginPromptManager(private val loginPromptConfig: LoginPromptConf
      *
      * @param supportFragmentManager Calling entity's fragment manager.
      */
-    fun showLoginPrompt(supportFragmentManager: FragmentManager) {
+    fun showLoginPromptIfAbsent(supportFragmentManager: FragmentManager) {
         val loginPromptFragment =
             supportFragmentManager.findFragmentByTag(fragmentTag) as? LoginPromptFragment
-                ?: initializeLoginPrompt(this.loginPromptConfig)
 
-        if (loginPromptFragment?.dialog?.isShowing == true) {
-            return
+        if (loginPromptFragment == null) {
+            initializeLoginPrompt(loginPromptConfig).show(supportFragmentManager, fragmentTag)
         }
-
-        loginPromptFragment.show(supportFragmentManager, fragmentTag)
     }
 
     private fun initializeLoginPrompt(config: LoginPromptConfig): LoginPromptFragment =

--- a/webflows/src/main/java/com/schibsted/account/webflows/loginPrompt/LoginPromptManager.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/loginPrompt/LoginPromptManager.kt
@@ -1,19 +1,19 @@
 package com.schibsted.account.webflows.loginPrompt
 
+import android.content.Intent
+import android.os.Bundle
+import android.os.Parcelable
 import androidx.fragment.app.FragmentManager
-import com.schibsted.account.webflows.client.Client
+import kotlinx.parcelize.Parcelize
 
-internal class LoginPromptConfig {
-    var client: Client
-    var isCancelable: Boolean
 
-    constructor(client: Client, isCancelable: Boolean = true) {
-        this.client = client
-        this.isCancelable = isCancelable
-    }
-}
+@Parcelize
+internal data class LoginPromptConfig(
+    val authIntent: Intent,
+    val isCancelable: Boolean = true
+) : Parcelable
 
-internal class LoginPromptManager(val loginPromptConfig: LoginPromptConfig) {
+internal class LoginPromptManager(private val loginPromptConfig: LoginPromptConfig) {
     private val fragmentTag = "schibsted_account_login_prompt"
 
     /**
@@ -22,10 +22,10 @@ internal class LoginPromptManager(val loginPromptConfig: LoginPromptConfig) {
      * @param supportFragmentManager Calling entity's fragment manager.
      */
     fun showLoginPrompt(supportFragmentManager: FragmentManager) {
-        var loginPromptFragment =
+        val loginPromptFragment =
             supportFragmentManager.findFragmentByTag(fragmentTag) as? LoginPromptFragment
-                ?: initializeLoginPrompt()
-        loginPromptFragment.loginPromptConfig = this.loginPromptConfig
+                ?: initializeLoginPrompt(this.loginPromptConfig)
+
         if (loginPromptFragment?.dialog?.isShowing == true) {
             return
         }
@@ -33,8 +33,10 @@ internal class LoginPromptManager(val loginPromptConfig: LoginPromptConfig) {
         loginPromptFragment.show(supportFragmentManager, fragmentTag)
     }
 
-    fun initializeLoginPrompt(): LoginPromptFragment {
-        var loginPromptFragment = LoginPromptFragment()
-        return loginPromptFragment
-    }
+    private fun initializeLoginPrompt(config: LoginPromptConfig): LoginPromptFragment =
+        LoginPromptFragment().apply {
+            arguments = Bundle().apply {
+                putParcelable(LoginPromptFragment.ARG_CONFIG, config)
+            }
+        }
 }


### PR DESCRIPTION
```
FATAL EXCEPTION: main
 Process: com.schibsted.account, PID: 18798
 kotlin.UninitializedPropertyAccessException: lateinit property loginPromptConfig has not been initialized
```

Repro steps:
-Turn on “Don’t keep activities” (Dev options of device)
-Open app, request prompt
-Minimize app
-Open app

This is adressed by 27ff9230a7dc59371e859e04d54a14c01e11b465

I've also spotted one more although I can not reporduce it. Stacktrace was pointing on situation where we were trying to add another prompt with the same tag. f6585d7539f68091b51c98e7da8ac854bd366fed should prevent such problems
