### PR TITLE
feat: NOJIRA Fix consumer-rules to keep com.nimbusds.jose JWK classes

### DIFF
--- a/webflows/consumer-rules.pro
+++ b/webflows/consumer-rules.pro
@@ -46,3 +46,7 @@
 -keep public enum com.schibsted.account.webflows.client.* {
     *;
 }
+
+# Prevent obfuscation of com.nimbusds.jose.* since they are using their own TypeToken implementation
+# which collides with gson
+-keep class com.nimbusds.jose.** { *; }


### PR DESCRIPTION
One of Klarta devs reported issue that when he was using minify the SDK was unstable and it throwed such error:
```
else if (superclass == TypeToken.class) {
      throw new IllegalStateException("TypeToken must be created with a type argument: new TypeToken<...>() {}; "
          + "When using code shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved.");
    }
```
The problem starts in:
```
schibstedAccountApi.getJwks { ... }
```
Is located in: 
```
com.nimbusds.jose.shaded.gson.reflect.TypeToken 
```
which is used during parsing:
```
com.nimbusds.jose.util.JSONObjectUtils.parse(...)
```
and results in such info:
```
Token error response: IdTokenNotValid(cause=UnexpectedError(message=Failed to fetch JWKS to validate ID Token))
```

The solution is pretty simple - lets keep classes inside this dependency.
Fix is confirmed with app dev.

