### PR TITLE
Return boolean value based on login prompt being shown or not

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -320,23 +320,24 @@ class Client {
      *
      * @param supportFragmentManager Activity's Fragment manager.
      * @param isCancelable set if loginPrompt should be cancelable by user.
+     * @return true if login prompt is shown, false otherwise.
      */
     @JvmOverloads
     suspend fun requestLoginPrompt(
         context: Context,
         supportFragmentManager: FragmentManager,
         isCancelable: Boolean = true
-    ) {
+    ) : Boolean {
         val internalSessionFound = hasSessionStorage(configuration.clientId)
 
-        if (!internalSessionFound && userHasSessionOnDevice(context.applicationContext)) {
+        return if (!internalSessionFound && userHasSessionOnDevice(context.applicationContext)) {
             LoginPromptManager(
                 LoginPromptConfig(
                     this.getAuthenticationIntent(context),
                     isCancelable
                 )
             ).showLoginPromptIfAbsent(supportFragmentManager)
-        }
+        } else false
     }
 
     private suspend fun hasSessionStorage(clientId: String) =

--- a/webflows/src/main/java/com/schibsted/account/webflows/loginPrompt/LoginPromptManager.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/loginPrompt/LoginPromptManager.kt
@@ -20,14 +20,16 @@ internal class LoginPromptManager(private val loginPromptConfig: LoginPromptConf
      * Show login prompt.
      *
      * @param supportFragmentManager Calling entity's fragment manager.
+     * @return true if login prompt is shown, false otherwise.
      */
-    fun showLoginPromptIfAbsent(supportFragmentManager: FragmentManager) {
+    fun showLoginPromptIfAbsent(supportFragmentManager: FragmentManager) : Boolean{
         val loginPromptFragment =
             supportFragmentManager.findFragmentByTag(fragmentTag) as? LoginPromptFragment
 
-        if (loginPromptFragment == null) {
+        return if (loginPromptFragment == null) {
             initializeLoginPrompt(loginPromptConfig).show(supportFragmentManager, fragmentTag)
-        }
+            true
+        } else false
     }
 
     private fun initializeLoginPrompt(config: LoginPromptConfig): LoginPromptFragment =


### PR DESCRIPTION
## Summary

While implementing Simplified Login in News Media, we want to prompt user once per time. 
With current API, it's not possible to get feedback on if prompt was shown or not. 
This simple PR is changing this adding boolean value on requestLoginPrompt.