### PR TITLE
Keep class constructor

### DIFF
--- a/webflows/consumer-rules.pro
+++ b/webflows/consumer-rules.pro
@@ -32,6 +32,7 @@
 # Data classes for HTTP JSON responses
 # https://r8.googlesource.com/r8/+/refs/heads/main/compatibility-faq.md#troubleshooting-gson
 -keepclassmembers class com.schibsted.account.webflows.api.* {
+ <init>(...);
  !transient <fields>;
 }
 


### PR DESCRIPTION
https://schibsted.ghe.com/app-foundation/android-hermes-app/issues/8326

As I've established this error

```
Token request error response: UnexpectedError(cause=com.google.gson.JsonIOException: Abstract classes can't be instantiated! Register an InstanceCreator or a TypeAdapter for this type. Class name: com.schibsted.account.webflows.api.UserTokenResponse)
```

Was caused by R8 stripping out UserTokenResponse constructor (as it's used by GSON only with reflection) and made GSON think this is an abstract class.

A simple fix is to explicitly tell R8 that constructors of all API classes should not be removed.


Before | After |
|--------|-------|
|   ![image](https://github.com/user-attachments/assets/c56a0c83-4e18-4344-a17c-81cec0ba6b71)     |   ![image](https://github.com/user-attachments/assets/91512311-8807-4ad7-806f-cfc985b769a9)    |