### PR TITLE
feat(storage): allow disabling legacy session migration from EncryptedSharedPreferences

### DIFF
--- a/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/Client.kt
@@ -62,15 +62,18 @@ class Client {
         this.configuration = configuration
         stateStorage = StateStorage(context.applicationContext)
 
-        val encryptedStorage = EncryptedSharedPrefsStorage(context.applicationContext)
         val sharedPrefsStorage =
             SharedPrefsStorage(context.applicationContext, configuration.serverUrl.toString())
 
-        sessionStorage =
+        sessionStorage = if (configuration.skipLegacySessionMigration) {
+            sharedPrefsStorage
+        } else {
+            val encryptedStorage = EncryptedSharedPrefsStorage(context.applicationContext)
             MigratingSessionStorage(
                 newStorage = sharedPrefsStorage,
                 previousStorage = encryptedStorage,
             )
+        }
 
         schibstedAccountApi =
             SchibstedAccountApi(configuration.serverUrl.toString().toHttpUrl(), httpClient)

--- a/webflows/src/main/java/com/schibsted/account/webflows/client/ClientConfiguration.kt
+++ b/webflows/src/main/java/com/schibsted/account/webflows/client/ClientConfiguration.kt
@@ -2,12 +2,23 @@ package com.schibsted.account.webflows.client
 
 import java.net.URL
 
-data class ClientConfiguration(val serverUrl: URL, val clientId: String, val redirectUri: String) {
+data class ClientConfiguration(
+    val serverUrl: URL,
+    val clientId: String,
+    val redirectUri: String,
+    val skipLegacySessionMigration: Boolean = false,
+) {
     val issuer: String = serverUrl.toString()
 
-    constructor(env: Environment, clientId: String, redirectUri: String) : this(
+    constructor(
+        env: Environment,
+        clientId: String,
+        redirectUri: String,
+        skipLegacySessionMigration: Boolean = false,
+    ) : this(
         env.url,
         clientId,
         redirectUri,
+        skipLegacySessionMigration,
     )
 }


### PR DESCRIPTION
Added a new `skipLegacySessionMigration` flag to `ClientConfiguration` to allow apps to opt out of migrating sessions from EncryptedSharedPrefsStorage.

When enabled, the SDK skips reading from the legacy keystore-backed storage, avoiding potential ANRs caused by blocking operations on the main thread— especially on Android 12 devices with slow or hardware-backed keystores.

Default behavior remains unchanged to preserve backward compatibility.